### PR TITLE
Fix notebook metadata

### DIFF
--- a/notebooks/usage_example.ipynb
+++ b/notebooks/usage_example.ipynb
@@ -301,6 +301,6 @@
    "display_name": "Python 3 (ipykernel)"
   }
  },
- "nbformat": 5,
- "nbformat_minor": 9
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
`nbformat` schemas only exist up to v4.5. Looks like a not-so-common but [known issue](https://github.com/jupyter/nbformat/issues/407), to do with `.ipynb` files created outside of Jupyter proper. Did you possibly use PyCharm to create this file?